### PR TITLE
fix: traverse  in schema files

### DIFF
--- a/.monoweave/6660209a.md
+++ b/.monoweave/6660209a.md
@@ -1,0 +1,4 @@
+---
+"@noahnu/validate-schema": patch
+---
+Traverse $refs in schema files.


### PR DESCRIPTION
If a schema file contains a `$ref`, we will download it and add it to AJV. For references to github's CDN, we will pass along a GITHUB_TOKEN if one is found in the current environment (https only).